### PR TITLE
[codex] Improve wrapper guidance and timeout handling

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - property-based fuzz tests and a scheduled fuzz workflow
 - a fuller published security policy with supported versions and reporting expectations
 - a documented `dev` integration branch strategy
+- earlier built-in guidance and wrapper hints for agents choosing between one-shot and session workflows
 
 ### Changed
 
 - wrapper docs and guidance now describe both one-shot and session-scoped smoke-test flows
+- one-shot calls now support separate `startupTimeoutMs` and `operationTimeoutMs`, with clearer phase-specific timeout errors
 - pinned GitHub Actions workflow dependencies to immutable commit SHAs
 - tightened workflow hardening beyond the initial branch protection and token-scope fixes
 - CI, CodeQL, and Fuzz workflows now validate both `main` and `dev`
+- the live `main` ruleset now requires the `fuzz` check alongside CI, CodeQL, and Scorecard
 
 ## [0.1.1] - 2026-03-28
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Point your main MCP client at this wrapper, then use one of the bridge tools wit
   "env": {
     "EXAMPLE_ENV": "value"
   },
-  "timeoutMs": 30000
+  "startupTimeoutMs": 30000,
+  "operationTimeoutMs": 30000
 }
 ```
 
@@ -111,7 +112,7 @@ Then ask your agent to:
 - call one target tool after each code change
 - verify resource reads or prompts
 
-If you need to preserve target process state across several calls, open an explicit session first and then use the `stdio_mcp_session_*` tools before closing it.
+Use one-shot mode for initial inspection and small stateless calls. If the target returns `jobId`-style handles, expects in-memory state between calls, or simply has expensive startup, open an explicit session first and then use the `stdio_mcp_session_*` tools before closing it.
 
 ## Tool Surface
 
@@ -122,7 +123,9 @@ Common launch fields:
 - `cwd`: optional target working directory
 - `inheritParentEnv`: when `true`, merge the wrapper process environment into the target launch
 - `env`: additional target environment variables
-- `timeoutMs`: max time for target launch and operation
+- `startupTimeoutMs`: optional one-shot startup and MCP initialize timeout
+- `operationTimeoutMs`: optional one-shot operation timeout
+- `timeoutMs`: legacy one-shot shortcut for both phases; session tools still use `timeoutMs`
 
 Bridge operations:
 
@@ -149,6 +152,12 @@ Wrapper guidance surfaces:
 
 - `wrapper://how-to-use`: plain-text usage guide
 - `tool_usage_guide`: prompt form of the same instructions
+
+Session mode is the better fit when:
+
+- the target returns deferred handles like `jobId`
+- follow-up calls must hit the same live target process
+- target startup is expensive enough that repeating it obscures the real feedback loop
 
 ## Safety Notes
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -37,18 +37,20 @@ Recommended:
 - require pull requests and passing checks on `main`
 - optionally allow a lighter rule set on `dev` if you want faster integration
 
-Suggested required checks on `main`:
+Current live `main` ruleset requires:
 
 - `CI`
+  - matrix `test` jobs on Windows and Linux for Node `20` and `22`
 - `CodeQL`
+  - `analyze (javascript-typescript)`
 - `Scorecard`
+  - `analysis`
 - `Fuzz`
+  - `fuzz`
 
-Suggested required checks on `dev`:
+Reasonable future tightening:
 
-- `CI`
-- `CodeQL`
-- `Fuzz`
+- require additional review approvals once there is at least one trusted non-owner reviewer
 
 ## Notes
 

--- a/docs/maintainer.md
+++ b/docs/maintainer.md
@@ -99,6 +99,14 @@ npm test
 - keep `main` on a repository ruleset rather than ad-hoc branch settings
 - keep force-push and deletion blocked on `main`
 - require PRs, passing checks, review-thread resolution, and linear history on `main`
+- keep the live required checks list aligned with the ruleset:
+  - `analysis`
+  - `analyze (javascript-typescript)`
+  - `fuzz`
+  - `test (ubuntu-latest, 20)`
+  - `test (ubuntu-latest, 22)`
+  - `test (windows-latest, 20)`
+  - `test (windows-latest, 22)`
 - keep the owner bypass narrow and temporary while there are no volunteer approvers
 
 ## Future Work

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,8 +1,8 @@
 # Tool Reference
 
-## Common Launch Fields
+## One-Shot Launch Fields
 
-Every bridge tool takes the same target launch fields:
+Every one-shot bridge tool takes the same target launch fields:
 
 - `command`
   - required target executable
@@ -15,9 +15,15 @@ Every bridge tool takes the same target launch fields:
   - when enabled, the wrapper process environment is merged into the target environment
 - `env`
   - additional target environment variables
+- `startupTimeoutMs`
+  - optional
+  - maximum time for target launch plus MCP initialize on one-shot calls
+- `operationTimeoutMs`
+  - optional
+  - maximum time for the one-shot MCP operation after startup succeeds
 - `timeoutMs`
-  - defaults to `30000`
-  - maximum time for the target launch plus the MCP operation
+  - optional legacy shortcut
+  - if provided, applies the same timeout to both one-shot phases
 
 ## Bridge Tools
 
@@ -28,6 +34,8 @@ Launches the target stdio MCP server and returns its declared tools.
 ### `stdio_mcp_call_tool`
 
 Launches the target server and calls one target tool.
+
+Prefer this for stateless single calls. If the target preserves in-memory state, returns deferred handles like `jobId`, or expects follow-up calls against one live process, open a wrapper session instead.
 
 Additional fields:
 
@@ -70,8 +78,17 @@ Additional fields:
 
 Launches the target stdio MCP server once and returns a wrapper-managed `sessionId`.
 
+Prefer this when:
+
+- the target returns `jobId`, `sessionId`, `relatedUpid`, or `waitMode: deferred`
+- follow-up tools need process-local target state
+- target startup is expensive and you plan several sequential MCP operations
+
 Additional fields:
 
+- `timeoutMs`
+  - defaults to `30000`
+  - maximum time for target launch plus MCP initialize before the session opens
 - `idleTimeoutMs`
   - defaults to `60000`
   - closes the session after this much inactivity
@@ -172,10 +189,35 @@ Built-in text guidance for operators and agents. This is the best starting point
 
 Built-in prompt that returns the same usage guidance for hosts that surface prompts more naturally than resources.
 
+## Choosing One-Shot vs Session Mode
+
+Use one-shot mode for:
+
+- initial inspection with `stdio_mcp_list_tools`
+- stateless reads
+- a single small synchronous tool call
+
+Use session mode for:
+
+- deferred or handle-based workflows
+- `job_*` style follow-up tools
+- anything that must reuse target in-memory state
+- several sequential calls where repeated startup is just noise
+
+Short stateful example:
+
+1. `stdio_mcp_open_session`
+2. `stdio_mcp_session_list_tools`
+3. `stdio_mcp_session_call_tool` for a target tool that returns a handle
+4. `stdio_mcp_session_call_tool` again for the follow-up call that consumes that handle
+5. `stdio_mcp_get_session` if you need wrapper-side diagnostics
+6. `stdio_mcp_close_session`
+
 ## Error Behavior
 
 - If the target process fails to launch or the target MCP operation fails, the wrapper returns an error to the caller.
 - If the target writes to stderr, the wrapper appends a tail of that stderr output to thrown launch errors when possible and includes `stderrTail` on error tool results when available.
-- If the target call exceeds `timeoutMs`, the wrapper fails the call with a timeout error.
+- One-shot timeouts identify whether the wrapper timed out during target launch and MCP initialize or during the target MCP operation.
+- Session open and session-scoped calls still use `timeoutMs` and fail with a timeout error when that phase exceeds its budget.
 - Session records remain inspectable after idle timeout, hard timeout, or unexpected target exit until the caller runs `stdio_mcp_close_session`.
 - Session-scoped calls fail immediately if the target session is already terminal or already serving another in-flight operation.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,9 +58,12 @@ Use one of the wrapper bridge tools with launch input like:
   "env": {
     "YOUR_ENV": "value"
   },
-  "timeoutMs": 30000
+  "startupTimeoutMs": 30000,
+  "operationTimeoutMs": 30000
 }
 ```
+
+Use one-shot mode first for stateless inspection. Switch to a wrapper session when the target returns handles like `jobId`, expects process-local state between calls, or simply takes long enough to start that repeated launch noise gets in the way.
 
 Recommended first smoke tests:
 
@@ -79,6 +82,13 @@ Use the session tools when a single target process must serve multiple MCP opera
 3. one or more `stdio_mcp_session_call_tool`, `stdio_mcp_session_read_resource`, or `stdio_mcp_session_get_prompt` calls
 4. `stdio_mcp_get_session` if you need wrapper-side diagnostics
 5. `stdio_mcp_close_session`
+
+Typical session triggers:
+
+- the target result includes `jobId`, `sessionId`, `relatedUpid`, or `waitMode: deferred`
+- the target exposes `job_*` or similar follow-up tools
+- the next call must hit the same in-memory target state
+- startup is expensive and you plan several sequential calls
 
 Sessions are still meant for short-lived smoke tests. The wrapper enforces idle and hard timeouts so abandoned target processes do not linger.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,12 @@ If you want a minimal isolated target environment, set `inheritParentEnv` to `fa
 
 ## The Call Hangs
 
-Set or lower `timeoutMs`.
+For one-shot tools:
+
+- raise `startupTimeoutMs` if the target is slow to boot or slow to finish MCP initialize
+- raise `operationTimeoutMs` if the target starts successfully but the actual tool, resource, or prompt operation is slow
+
+For `stdio_mcp_open_session` and the `stdio_mcp_session_*` tools, adjust `timeoutMs`.
 
 Common causes:
 
@@ -49,5 +54,7 @@ Each bridge call launches a fresh target process, so this project is best for:
 
 - smoke tests
 - repeated sanity checks during development
+
+If the startup cost is the main problem, switch to the explicit session tools for a short bounded run instead of repeating one-shot launches.
 
 It is not designed as a persistent low-latency proxy.

--- a/index.mjs
+++ b/index.mjs
@@ -9,6 +9,7 @@ import {
   DEFAULT_HARD_TIMEOUT_MS,
   DEFAULT_IDLE_TIMEOUT_MS,
   DEFAULT_OPERATION_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
   buildLaunchEnv,
   tailText,
   usageGuideText,
@@ -30,36 +31,47 @@ const server = new McpServer(
   serverInfo,
   {
     instructions:
-      "Development-focused MCP wrapper for smoke-testing another stdio MCP server. Start with the wrapper usage resource or prompt, then use stdio_mcp_list_tools before stdio_mcp_call_tool. One-shot bridge calls launch a fresh target stdio server for each operation, and the optional session API keeps a bounded target process alive across several operations.",
+      "Development-focused MCP wrapper for smoke-testing another stdio MCP server. Start with the wrapper usage resource or prompt, then use stdio_mcp_list_tools before stdio_mcp_call_tool. One-shot bridge calls launch a fresh target stdio server for each operation. If the target needs process-local state, returns deferred handles, or has expensive startup, use the bounded session API instead.",
   },
 );
 
 const sessionManager = new SessionManager(clientInfo);
 
 const envSchema = z.record(z.string(), z.string()).default({});
-const timeoutMsSchema = z.number().int().positive().max(300000).default(DEFAULT_OPERATION_TIMEOUT_MS);
+const timeoutMsSchema = z.number().int().positive().max(MAX_TIMEOUT_MS);
+const sessionTimeoutMsSchema = timeoutMsSchema.default(DEFAULT_OPERATION_TIMEOUT_MS);
 const sessionLifetimeSchema = z.number().int().positive().max(3600000);
 const sessionIdSchema = z.string().min(1).describe("Session identifier returned by stdio_mcp_open_session.");
 
-const launchSchema = {
+const baseLaunchSchema = {
   command: z.string().min(1).describe("Executable to launch for the target stdio MCP server."),
   args: z.array(z.string()).default([]).describe("Command arguments for the target server."),
   cwd: z.string().optional().describe("Optional working directory for the target server."),
   inheritParentEnv: z.boolean().default(true).describe("When true, merge the wrapper process environment into the target launch environment."),
   env: envSchema.describe("Additional environment variables for the target server."),
-  timeoutMs: timeoutMsSchema.describe("Maximum time to allow the target launch and MCP operation before failing."),
+};
+
+const oneShotLaunchSchema = {
+  ...baseLaunchSchema,
+  timeoutMs: timeoutMsSchema.optional().describe("Legacy shortcut that applies the same timeout to one-shot target startup and the one-shot MCP operation."),
+  startupTimeoutMs: timeoutMsSchema.optional().describe("Maximum time to allow one-shot target launch and MCP initialize before failing."),
+  operationTimeoutMs: timeoutMsSchema.optional().describe("Maximum time to allow the one-shot MCP operation after startup before failing."),
 };
 
 const sessionLaunchSchema = {
-  ...launchSchema,
+  ...baseLaunchSchema,
+  timeoutMs: sessionTimeoutMsSchema.describe("Maximum time to allow target launch and MCP initialize before the wrapper session opens."),
   idleTimeoutMs: sessionLifetimeSchema.default(DEFAULT_IDLE_TIMEOUT_MS).describe("Maximum idle time before the wrapper closes the session."),
   hardTimeoutMs: sessionLifetimeSchema.default(DEFAULT_HARD_TIMEOUT_MS).describe("Maximum total lifetime before the wrapper closes the session."),
 };
 
 const sessionOperationSchema = {
   sessionId: sessionIdSchema,
-  timeoutMs: timeoutMsSchema.describe("Maximum time to allow the session-scoped MCP operation before failing."),
+  timeoutMs: sessionTimeoutMsSchema.describe("Maximum time to allow the session-scoped MCP operation before failing."),
 };
+
+const statefulHintText =
+  "This one-shot result looks stateful. If follow-up calls must reuse this handle or target in-memory state, prefer stdio_mcp_open_session and the stdio_mcp_session_* tools.";
 
 function textResult(title, data, isError = false) {
   return {
@@ -74,7 +86,60 @@ function textResult(title, data, isError = false) {
   };
 }
 
-function toolResult(name, result, stderrTailText = "") {
+function isStatefulToolName(name) {
+  return /(^|_)(job|session)(_|$)/i.test(name);
+}
+
+function hasStatefulSignal(value, visited = new Set()) {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value !== "object") {
+    return false;
+  }
+  if (visited.has(value)) {
+    return false;
+  }
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasStatefulSignal(item, visited));
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === "jobId" || key === "sessionId" || key === "relatedUpid") {
+      return true;
+    }
+    if (key === "waitMode" && nested === "deferred") {
+      return true;
+    }
+    if (hasStatefulSignal(nested, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function buildOneShotToolHints(name, result) {
+  if (result.isError) {
+    return [];
+  }
+  if (isStatefulToolName(name) || hasStatefulSignal(result.structuredContent)) {
+    return [statefulHintText];
+  }
+  return [];
+}
+
+function resolveOneShotTimeouts(launch) {
+  return {
+    ...launch,
+    startupTimeoutMs: launch.startupTimeoutMs ?? launch.timeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+    operationTimeoutMs: launch.operationTimeoutMs ?? launch.timeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+  };
+}
+
+function toolResult(name, result, stderrTailText = "", wrapperHints = []) {
   return textResult(
     `Target MCP tool ${name}`,
     {
@@ -82,13 +147,30 @@ function toolResult(name, result, stderrTailText = "") {
       structuredContent: result.structuredContent ?? null,
       isError: result.isError ?? false,
       stderrTail: (result.isError ? stderrTailText : "") || null,
+      wrapperHints: wrapperHints.length > 0 ? wrapperHints : null,
     },
     result.isError ?? false,
   );
 }
 
+function buildListToolsHints(listed) {
+  const hasStatefulWorkflowSignal = listed.tools.some((tool) => {
+    const description = typeof tool.description === "string" ? tool.description : "";
+    return isStatefulToolName(tool.name) || /\bdeferred\b|\bstateful\b/i.test(description);
+  });
+  if (!hasStatefulWorkflowSignal) {
+    return null;
+  }
+  return [
+    "This target exposes likely stateful workflow tools. If follow-up calls must reuse handles or in-memory target state, prefer stdio_mcp_open_session and the stdio_mcp_session_* tools.",
+  ];
+}
+
 function listToolsResult(listed) {
-  return textResult("Target MCP tools", { tools: listed.tools });
+  return textResult("Target MCP tools", {
+    tools: listed.tools,
+    wrapperHints: buildListToolsHints(listed),
+  });
 }
 
 function listResourcesResult(listed) {
@@ -108,11 +190,12 @@ function getPromptResult(name, result) {
 }
 
 async function withClient(launch, work) {
+  const normalizedLaunch = resolveOneShotTimeouts(launch);
   const transport = new StdioClientTransport({
-    command: launch.command,
-    args: launch.args,
-    cwd: launch.cwd,
-    env: buildLaunchEnv(launch),
+    command: normalizedLaunch.command,
+    args: normalizedLaunch.args,
+    cwd: normalizedLaunch.cwd,
+    env: buildLaunchEnv(normalizedLaunch),
     stderr: "pipe",
   });
 
@@ -124,16 +207,19 @@ async function withClient(launch, work) {
   const client = new Client(clientInfo, { capabilities: {} });
 
   try {
+    await withTimeout(
+      client.connect(transport),
+      normalizedLaunch.startupTimeoutMs,
+      "Target launch and MCP initialize",
+    );
     return await withTimeout(
-      (async () => {
-        await client.connect(transport);
-        return work(client, {
-          stderrTail() {
-            return stderr;
-          },
-        });
-      })(),
-      launch.timeoutMs,
+      work(client, {
+        stderrTail() {
+          return stderr;
+        },
+      }),
+      normalizedLaunch.operationTimeoutMs,
+      "Target MCP operation",
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -184,8 +270,8 @@ server.registerPrompt(
 server.registerTool(
   "stdio_mcp_list_tools",
   {
-    description: "Launch a target stdio MCP server and list its tools.",
-    inputSchema: launchSchema,
+    description: "Launch a target stdio MCP server and list its tools. Best for first-pass inspection; if the target has expensive startup or stateful follow-up work, open a wrapper session instead.",
+    inputSchema: oneShotLaunchSchema,
   },
   async (launch) =>
     withClient(launch, async (client) => {
@@ -197,9 +283,9 @@ server.registerTool(
 server.registerTool(
   "stdio_mcp_call_tool",
   {
-    description: "Launch a target stdio MCP server and call one of its tools.",
+    description: "Launch a target stdio MCP server and call one of its tools. Best for stateless single calls; if the target preserves in-memory state or returns deferred handles, prefer stdio_mcp_open_session and stdio_mcp_session_call_tool.",
     inputSchema: {
-      ...launchSchema,
+      ...oneShotLaunchSchema,
       name: z.string().min(1).describe("Target tool name."),
       arguments: z.record(z.string(), z.unknown()).default({}).describe("Arguments to pass to the target tool."),
     },
@@ -210,15 +296,15 @@ server.registerTool(
         name,
         arguments: toolArguments,
       });
-      return toolResult(name, result, context.stderrTail());
+      return toolResult(name, result, context.stderrTail(), buildOneShotToolHints(name, result));
     }),
 );
 
 server.registerTool(
   "stdio_mcp_list_resources",
   {
-    description: "Launch a target stdio MCP server and list its resources.",
-    inputSchema: launchSchema,
+    description: "Launch a target stdio MCP server and list its resources. Prefer a wrapper session if several stateful follow-up operations must hit the same target process.",
+    inputSchema: oneShotLaunchSchema,
   },
   async (launch) =>
     withClient(launch, async (client) => {
@@ -230,9 +316,9 @@ server.registerTool(
 server.registerTool(
   "stdio_mcp_read_resource",
   {
-    description: "Launch a target stdio MCP server and read one resource URI.",
+    description: "Launch a target stdio MCP server and read one resource URI. Use a wrapper session instead when related calls must share one live target process.",
     inputSchema: {
-      ...launchSchema,
+      ...oneShotLaunchSchema,
       uri: z.string().min(1).describe("Resource URI to read."),
     },
   },
@@ -246,8 +332,8 @@ server.registerTool(
 server.registerTool(
   "stdio_mcp_list_prompts",
   {
-    description: "Launch a target stdio MCP server and list its prompts.",
-    inputSchema: launchSchema,
+    description: "Launch a target stdio MCP server and list its prompts. Use a wrapper session when prompt reads are part of a larger stateful target workflow.",
+    inputSchema: oneShotLaunchSchema,
   },
   async (launch) =>
     withClient(launch, async (client) => {
@@ -259,9 +345,9 @@ server.registerTool(
 server.registerTool(
   "stdio_mcp_get_prompt",
   {
-    description: "Launch a target stdio MCP server and fetch one prompt definition.",
+    description: "Launch a target stdio MCP server and fetch one prompt definition. Prefer a wrapper session when follow-up work must reuse the same target process.",
     inputSchema: {
-      ...launchSchema,
+      ...oneShotLaunchSchema,
       name: z.string().min(1).describe("Prompt name."),
       arguments: z.record(z.string(), z.string()).default({}).describe("Prompt arguments."),
     },
@@ -279,7 +365,7 @@ server.registerTool(
 server.registerTool(
   "stdio_mcp_open_session",
   {
-    description: "Launch a target stdio MCP server and keep it alive for multiple MCP operations.",
+    description: "Launch a target stdio MCP server and keep it alive for multiple MCP operations. Use this when follow-up calls need the same target process, deferred handles, or expensive startup reuse.",
     inputSchema: sessionLaunchSchema,
   },
   async (launch) => textResult("Wrapper session opened", await sessionManager.openSession(launch)),

--- a/lib/core.mjs
+++ b/lib/core.mjs
@@ -1,6 +1,7 @@
 export const DEFAULT_OPERATION_TIMEOUT_MS = 30000;
 export const DEFAULT_IDLE_TIMEOUT_MS = 60000;
 export const DEFAULT_HARD_TIMEOUT_MS = 300000;
+export const MAX_TIMEOUT_MS = 3600000;
 export const STDERR_TAIL_MAX_CHARS = 4000;
 
 export const usageGuideText = `MCP Stdio Wrapper usage guide
@@ -22,6 +23,15 @@ Optional session sequence:
 4. Inspect diagnostics with stdio_mcp_get_session if needed.
 5. Close the session with stdio_mcp_close_session.
 
+Choose one-shot mode when:
+- You are doing initial inspection, stateless reads, or one small synchronous tool call.
+- You want a fresh target process on every smoke test.
+
+Choose session mode when:
+- The target returns handles such as jobId, sessionId, relatedUpid, or waitMode: deferred.
+- The target exposes job_* style follow-up tools or otherwise keeps in-memory state between calls.
+- Target startup is expensive and you plan to run several sequential MCP operations.
+
 Behavior:
 - One-shot bridge calls launch a fresh target process.
 - The wrapper only keeps target session state when you explicitly open a session.
@@ -34,7 +44,9 @@ Important launch fields:
 - cwd: optional target working directory
 - inheritParentEnv: merge the wrapper environment into the target launch
 - env: extra target environment variables
-- timeoutMs: operation timeout in milliseconds
+- startupTimeoutMs: optional one-shot launch and MCP initialize timeout in milliseconds
+- operationTimeoutMs: optional one-shot MCP operation timeout in milliseconds
+- timeoutMs: legacy one-shot shortcut for both phases; session tools still use timeoutMs per open or per session-scoped call
 
 Safety:
 - Only launch trusted local target commands.
@@ -51,13 +63,13 @@ export function buildLaunchEnv(launch, parentEnv = process.env) {
   return launch.inheritParentEnv ? { ...parentEnv, ...launch.env } : launch.env;
 }
 
-export async function withTimeout(promise, timeoutMs) {
+export async function withTimeout(promise, timeoutMs, label = "Target operation") {
   let timer;
   try {
     return await Promise.race([
       promise,
       new Promise((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`Target operation timed out after ${timeoutMs} ms.`)), timeoutMs);
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs} ms.`)), timeoutMs);
       }),
     ]);
   } finally {

--- a/tests/fake-target.mjs
+++ b/tests/fake-target.mjs
@@ -73,6 +73,21 @@ server.registerTool(
 );
 
 server.registerTool(
+  "deferred_handle_tool",
+  {
+    description: "Return a stateful-looking deferred handle.",
+    inputSchema: {},
+  },
+  async () => ({
+    content: [{ type: "text", text: "job-123" }],
+    structuredContent: {
+      jobId: "job-123",
+      waitMode: "deferred",
+    },
+  }),
+);
+
+server.registerTool(
   "stderr_tool",
   {
     description: "Write lines to stderr and succeed.",
@@ -151,4 +166,8 @@ server.registerPrompt(
 );
 
 const transport = new StdioServerTransport();
+const startupDelayMs = Number.parseInt(process.env.FAKE_TARGET_STARTUP_DELAY_MS ?? "0", 10);
+if (Number.isFinite(startupDelayMs) && startupDelayMs > 0) {
+  await new Promise((resolve) => setTimeout(resolve, startupDelayMs));
+}
 await server.connect(transport);

--- a/tests/wrapper.test.mjs
+++ b/tests/wrapper.test.mjs
@@ -69,6 +69,7 @@ test("lists tools from a target stdio MCP server", async () => {
     assert.equal(result.isError, false);
     const names = result.structuredContent.tools.map((tool) => tool.name);
     assert.ok(names.includes("echo_tool"));
+    assert.match(result.structuredContent.wrapperHints[0], /stdio_mcp_open_session/);
   });
 });
 
@@ -81,6 +82,7 @@ test("exposes a wrapper usage resource", async () => {
     const result = await client.readResource({ uri: "wrapper://how-to-use" });
     assert.match(JSON.stringify(result), /stdio_mcp_list_tools/);
     assert.match(JSON.stringify(result), /stdio_mcp_open_session/);
+    assert.match(JSON.stringify(result), /jobId/);
   });
 });
 
@@ -106,6 +108,21 @@ test("calls a target MCP tool", async () => {
 
     assert.equal(result.structuredContent.isError, false);
     assert.equal(result.structuredContent.structuredContent.echoed, "wrapper-ok");
+    assert.equal(result.structuredContent.wrapperHints, null);
+  });
+});
+
+test("adds a wrapper hint when a one-shot tool result looks stateful", async () => {
+  await withWrapper(async (client) => {
+    const result = await callWrapperTool(client, "stdio_mcp_call_tool", {
+      ...launchInput(),
+      name: "deferred_handle_tool",
+      arguments: {},
+    });
+
+    assert.equal(result.isError, false);
+    assert.equal(result.structuredContent.structuredContent.jobId, "job-123");
+    assert.match(result.structuredContent.wrapperHints[0], /stdio_mcp_open_session/);
   });
 });
 
@@ -154,6 +171,30 @@ test("includes target stderr details when the target tool fails", async () => {
 
     assert.equal(result.isError, true);
     assert.match(result.structuredContent.stderrTail, /fake-target failure: boom/);
+  });
+});
+
+test("supports split one-shot startup and operation timeouts", async () => {
+  await withWrapper(async (client) => {
+    const startupTimeout = await callWrapperTool(client, "stdio_mcp_list_tools", {
+      ...launchInput(),
+      env: {
+        FAKE_TARGET_STARTUP_DELAY_MS: "200",
+      },
+      startupTimeoutMs: 50,
+    });
+    assert.equal(startupTimeout.isError, true);
+    assert.match(toolText(startupTimeout), /Target launch and MCP initialize timed out after 50 ms/);
+
+    const operationTimeout = await callWrapperTool(client, "stdio_mcp_call_tool", {
+      ...launchInput(),
+      name: "slow_tool",
+      arguments: { delayMs: 200 },
+      startupTimeoutMs: 1000,
+      operationTimeoutMs: 50,
+    });
+    assert.equal(operationTimeout.isError, true);
+    assert.match(toolText(operationTimeout), /Target MCP operation timed out after 50 ms/);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR tightens how the wrapper guides agents and operators toward the right execution mode and makes one-shot timeout behavior easier to reason about.

It also aligns the repo docs with the current GitHub governance state after the live `main` ruleset update that now requires the `fuzz` check.

## What Changed

- strengthened the built-in wrapper usage guidance so one-shot vs session mode is explained directly in the tool surface
- added wrapper hints when a target tool list or one-shot tool result looks stateful and sessions are likely the better fit
- split one-shot timeout handling into `startupTimeoutMs` and `operationTimeoutMs` while keeping `timeoutMs` as a compatibility fallback
- expanded tests to cover stateful hints and split timeout behavior
- updated README and docs to match the current behavior and repo rules

## Why

Issues #10 and #13 exposed the original stateful-workflow gap, which is already solved by the explicit session API.
Issue #15 showed the remaining problem: agents could still fall into one-shot mode too long because the wrapper was not opinionated enough about when sessions were the right tool.
Issue #16 also identified that a single timeout budget was too coarse for real development loops because target startup and target operations are different failure modes.

This PR addresses the guidance problem directly and implements the timeout-splitting portion of #16 without turning the wrapper into a larger orchestration system.

## Impact

- agents should discover session mode earlier when the target surface or result shape suggests stateful workflows
- timeout failures on one-shot calls are more actionable because they now identify whether the wrapper timed out during startup/initialize or during the actual MCP operation
- repo documentation now reflects the current live branch-protection posture more accurately

## Validation

- `npm run check`
- `npm test`

## GitHub Follow-Up

- closed #10 because session-scoped target process support is already implemented
- closed #13 because deferred/stateful follow-up workflows are already supported through wrapper-managed sessions
- closed #15 because the wrapper now provides stronger built-in guidance and stateful-workflow hints
- updated the live `main` ruleset outside this PR to require the `fuzz` check in addition to the existing required checks

## Remaining Follow-Up

- issue #14 remains open for broader long-running operation ergonomics
- issue #16 remains partially open for reusable launch profiles or named targets
- issue #7 remains open for the remaining Scorecard backlog items